### PR TITLE
Fixing error in column names

### DIFF
--- a/04 - Class vs Static Methods/codesnippets/items.csv
+++ b/04 - Class vs Static Methods/codesnippets/items.csv
@@ -1,4 +1,4 @@
-name, price, quantity
+name,price,quantity
 "Phone",100,1
 "Laptop",1000,3
 "Cable",10,5


### PR DESCRIPTION
column names should be "name,price,quantity" not "name, price, quantity", otherwise list item will be {'name': 'Phone', ' price': '100', ' quantity': '1'} when reading CSV